### PR TITLE
use function in rhs for example vim.keymap.set

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,11 @@ movement of `rh` and `rl` inverted compare to as we expected.
 So, this plugin provide `resize` function for such purpose. You can use it as follow.
 
 ```lua
-local resize = require("winresize").resize
+local resize = function(win, amt, dir)
+    return function()
+        require("winresize").resize(wind, amt, dir)
+    end
+end
 vim.keymap.set("n", "rh", resize(0, 2, "left"))
 vim.keymap.set("n", "rj", resize(0, 1, "down"))
 vim.keymap.set("n", "rk", resize(0, 1, "up"))


### PR DESCRIPTION
Awesome plugin 👨‍🍳 💋 

I've been meaning to hack my way to something like this and this just does it so well, congrats and thanks.

While setting this up following the docs, I ran into the following issue when using the provided key mappings

```lua
local resize = require("winresize").resize
vim.keymap.set("n", "rh", resize(0, 2, "left"))
vim.keymap.set("n", "rj", resize(0, 1, "down"))
vim.keymap.set("n", "rk", resize(0, 1, "up"))
```

I was getting back

```
Diagnostics:
1. Cannot assign `nil` to parameter `string|function`.
   - `nil` cannot match `string|function`
   - `nil` cannot match any subtypes in `string|function`
   - Type `nil` cannot match `function`
   - Type `nil` cannot match `string` [param-type-mismatch]
```

I liked how you had the `resize` calls setup so deferring the function solved that issue, sending this back in case anyone else hits this issue as well.